### PR TITLE
(fix): Boolean typo in docs

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -168,7 +168,7 @@ class PostRequest(JsonRequest):
 In case validation fails to pass, the following is the format of the generated response:
 ```js
 {
-    success: 'False',
+    success: False,
     message: 'Validation error',
     errors: {
         'email': [


### PR DESCRIPTION
# What this PR does

- fix 'False' typo to False boolean in docs

[Delivers #bg]